### PR TITLE
add the hover effect to the social icons at footer

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "hotel-management-client",
 			"version": "0.0.0",
 			"dependencies": {
+				"hotel-management-client": "file:",
 				"html2pdf.js": "^0.10.2",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
@@ -3682,6 +3683,10 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/hotel-management-client": {
+			"resolved": "",
+			"link": true
 		},
 		"node_modules/html2canvas": {
 			"version": "1.4.1",

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
 		"serve": "serve -s dist"
 	},
 	"dependencies": {
+		"hotel-management-client": "file:",
 		"html2pdf.js": "^0.10.2",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",

--- a/client/src/components/Footer.jsx
+++ b/client/src/components/Footer.jsx
@@ -5,7 +5,9 @@ const Footer = () => {
 	return (
 		<div className="flex md:flex-row flex-col justify-around w-full p-5 gap-4 font-play border-y-4 border-gray bg-zinc-800 text-gray">
 			<div className="flex flex-col items-start gap-4">
-				<p className="font-bold text-2xl">Find anything you want</p>
+				<p className="font-bold text-2xl">
+					Find anything you want
+				</p>
 				<form>
 					<input
 						type="text"
@@ -24,18 +26,42 @@ const Footer = () => {
 				<img src={logoBackground} className="w-40" />
 				<div className="flex flex-wrap gap-4">
 					<div className="flex flex-col">
-						{footerLinks.slice(0, 2).map((link) => (
-							<a href={link.id} key={link.id} className="hover:text-orange">
-								{link.title}
-							</a>
-						))}
+						{footerLinks
+							.slice(0, 2)
+							.map((link) => (
+								<a
+									href={
+										link.id
+									}
+									key={
+										link.id
+									}
+									className="hover:text-orange"
+								>
+									{
+										link.title
+									}
+								</a>
+							))}
 					</div>
 					<div className="flex flex-col">
-						{footerLinks.slice(2, 4).map((link) => (
-							<a href={link.id} key={link.id} className="hover:text-orange">
-								{link.title}
-							</a>
-						))}
+						{footerLinks
+							.slice(2, 4)
+							.map((link) => (
+								<a
+									href={
+										link.id
+									}
+									key={
+										link.id
+									}
+									className="hover:text-orange"
+								>
+									{
+										link.title
+									}
+								</a>
+							))}
 					</div>
 				</div>
 
@@ -45,9 +71,12 @@ const Footer = () => {
 							href={link.url}
 							key={link.id}
 							target="_blank"
-							className="hover:opacity-80"
+							className="hover:bg-orange p-1 rounded-full"
 						>
-							<img src={link.icon} className="w-6" />
+							<img
+								src={link.icon}
+								className="w-6"
+							/>
 						</a>
 					))}
 				</div>


### PR DESCRIPTION
Make the social icons at the footer have a hover effect that changes the background color to orange (be the same as the color of text when hover) in the shape of a circle (surrounding the icon). The reason for the circle is because the page also has a circle at the center under the title of every pages (under "HOME", "ROOM LIST", "BOOKING LIST", etc).

The effect looks like this (apply to all social icons)
![image](https://github.com/user-attachments/assets/a2406e77-571d-48d0-8f81-7243a3aa0dbd)